### PR TITLE
fix: remove unnecessary calls to Retain

### DIFF
--- a/jsc/src/class.rs
+++ b/jsc/src/class.rs
@@ -1,9 +1,7 @@
 use std::ffi::CString;
 use std::ptr;
 
-use jsc_sys::{
-  JSClassCreate, JSClassDefinition, JSClassRef, JSClassRelease, JSClassRetain, JSObjectMake,
-};
+use jsc_sys::{JSClassCreate, JSClassDefinition, JSClassRef, JSClassRelease, JSObjectMake};
 
 use crate::{Context, JscError, Object};
 
@@ -60,7 +58,6 @@ impl ClassDefinition {
     if class_ref.is_null() {
       return Err(JscError::CreateClassError);
     }
-    unsafe { JSClassRetain(class_ref) };
     Ok(Class { inner: class_ref })
   }
 }

--- a/jsc/src/lib.rs
+++ b/jsc/src/lib.rs
@@ -3,10 +3,9 @@ use std::ptr;
 
 use jsc_sys::{
   JSContextGetGlobalObject, JSContextGroupCreate, JSContextGroupRef, JSContextGroupRelease,
-  JSContextGroupRetain, JSEvaluateScript, JSGarbageCollect, JSGlobalContextCreateInGroup,
-  JSGlobalContextRef, JSGlobalContextRelease, JSGlobalContextRetain,
-  JSObjectCallAsFunctionCallback, JSObjectMakeFunctionWithCallback, JSStringCreateWithUTF8CString,
-  JSStringRef, JSValueRef,
+  JSEvaluateScript, JSGarbageCollect, JSGlobalContextCreateInGroup, JSGlobalContextRef,
+  JSGlobalContextRelease, JSObjectCallAsFunctionCallback, JSObjectMakeFunctionWithCallback,
+  JSStringCreateWithUTF8CString, JSStringRef, JSValueRef,
 };
 
 mod class;
@@ -40,7 +39,6 @@ impl Context {
     if group.is_null() {
       return Err(JscError::CreateContextGroupError);
     }
-    unsafe { JSContextGroupRetain(group) };
     let inner = unsafe {
       JSGlobalContextCreateInGroup(
         group,
@@ -50,7 +48,6 @@ impl Context {
     if inner.is_null() {
       return Err(JscError::CreateGlobalContextError);
     }
-    unsafe { JSGlobalContextRetain(inner) };
     Ok(Context { group, inner })
   }
 


### PR DESCRIPTION
According to [the Create rule](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-103029) and [tests from the WebKit repo](https://github.com/WebKit/WebKit/blob/607499977734f77ef66a84a9df7f9b2bf4a03278/Source/JavaScriptCore/API/tests/testapi.c#L1126) it looks like it isn't necessary to call `Retain` after a JSC object is created by calling a `Create` function. `Retain`-ing the objects prevents the refcount from decrementing to zero.